### PR TITLE
♻️ Rename `power_matrix` --> `exponent_matrix`

### DIFF
--- a/desr/ode_system.py
+++ b/desr/ode_system.py
@@ -941,7 +941,7 @@ class ODESystem(object):
                 raise RuntimeError(f'variable `{v}` appears to not actually be a single variable.  have {found_vars}')
 
 
-    def power_matrix(self):
+    def exponent_matrix(self):
         '''
         Determine the 'exponent' or 'power' matrix of the system, denoted by :math:`K` in the literature,
         by gluing together the power matrices of each derivative, initial condition, constraint, and require-same-variable.
@@ -954,7 +954,7 @@ class ODESystem(object):
         >>> system = ODESystem.from_equations(eqns)
         >>> system.variables
         (t, c, s, e_0, k_1, k_2, k_m1)
-        >>> system.power_matrix()
+        >>> system.exponent_matrix()
         Matrix([
         [1, 1, 1,  1, 1, 1,  1],
         [0, 0, 0, -1, 0, 1,  1],
@@ -970,7 +970,7 @@ class ODESystem(object):
             * Change the code to agree with the paper.
 
         >>> system.update_initial_conditions({'s': 's_0'})
-        >>> system.power_matrix()
+        >>> system.exponent_matrix()
         Matrix([
         [1, 1, 1,  1, 1, 1,  1,  0],
         [0, 0, 0, -1, 0, 1,  1,  0],
@@ -984,7 +984,7 @@ class ODESystem(object):
 
         exprs = self._expressions()
 
-        matrices = [rational_expr_to_power_matrix(expr, self.variables) for expr in exprs]
+        matrices = [rational_expr_to_exponent_matrix(expr, self.variables) for expr in exprs]
         out = sympy.Matrix.hstack(*matrices)
         assert out.shape[0] == len(self.variables)
         return out
@@ -1098,7 +1098,7 @@ def parse_de(diff_eq, indep_var='t'):
     # Feed in _clash1 so that we can use variables S, C, etc., which are special characters in sympy.
     return sympy.var(match.group(1)), sympy.sympify(match.group(3), _clash1)
 
-def rational_expr_to_power_matrix(expr, variables):
+def rational_expr_to_exponent_matrix(expr, variables):
     '''
     Take a rational expression and determine the power matrix wrt an ordering on the variables, as on page 497 of
     Hubert-Labahn.
@@ -1107,7 +1107,7 @@ def rational_expr_to_power_matrix(expr, variables):
     >>> variables = sorted(expressions_to_variables(exprs), key=str)
     >>> variables
     [K, d, h, k, n, p, r, s]
-    >>> rational_expr_to_power_matrix(exprs[0], variables)
+    >>> rational_expr_to_exponent_matrix(exprs[0], variables)
     Matrix([
     [0, -1, -1, 0, 0,  0],
     [0,  1,  0, 1, 0,  1],
@@ -1118,7 +1118,7 @@ def rational_expr_to_power_matrix(expr, variables):
     [0,  1,  1, 1, 1,  0],
     [0,  0,  0, 0, 0,  0]])
 
-    >>> rational_expr_to_power_matrix(exprs[1], variables)
+    >>> rational_expr_to_exponent_matrix(exprs[1], variables)
     Matrix([
     [ 0, 0],
     [ 0, 0],
@@ -1181,11 +1181,11 @@ def maximal_scaling_matrix(exprs, variables=None):
     '''
     if variables is None:
         variables = sorted(expressions_to_variables(exprs), key=str)
-    matrices = [rational_expr_to_power_matrix(expr, variables) for expr in exprs]
-    power_matrix = sympy.Matrix.hstack(*matrices)
-    assert power_matrix.shape[0] == len(variables)
+    matrices = [rational_expr_to_exponent_matrix(expr, variables) for expr in exprs]
+    exponent_matrix = sympy.Matrix.hstack(*matrices)
+    assert exponent_matrix.shape[0] == len(variables)
 
-    hermite_rform, multiplier_rform = hnf_row(power_matrix)
+    hermite_rform, multiplier_rform = hnf_row(exponent_matrix)
 
     # Find the non-zero rows at the bottom
     row_is_zero = [all([i == 0 for i in row]) for row in hermite_rform.tolist()]
@@ -1200,7 +1200,7 @@ def maximal_scaling_matrix(exprs, variables=None):
     # Return the last num_nonzero rows of the Hermite multiplier
     return hnf_row(multiplier_rform[-num_nonzero:, :])[0]
 
-__all__ = ['ODESystem','parse_de','rational_expr_to_power_matrix','maximal_scaling_matrix']
+__all__ = ['ODESystem','parse_de','rational_expr_to_exponent_matrix','maximal_scaling_matrix']
 
 if __name__ == '__main__':
     import doctest

--- a/desr/unittests.py
+++ b/desr/unittests.py
@@ -433,7 +433,7 @@ class TestInitialConditions(TestCase):
         variables = ['t', 's', 'c', 'K', 'k_2', 'k_1', 'e_0']
         original_system.reorder_variables(variables)
         self.assertEqual(variables, map(str, original_system.variables))
-        self.assertEqual(original_system.power_matrix(), sympy.Matrix([[ 1, 1,  1, 1, 1, 1,  1],
+        self.assertEqual(original_system.exponent_matrix(), sympy.Matrix([[ 1, 1,  1, 1, 1, 1,  1],
                                                                        [-1, 0, -1, 0, 0, 1,  1],
                                                                        [ 1, 0,  1, 1, 0, 0, -1],
                                                                        [ 0, 0,  1, 0, 1, 0,  0],
@@ -450,7 +450,7 @@ class TestInitialConditions(TestCase):
                             set(map(lambda t: (sympy.sympify(t[0]), sympy.sympify(t[1])),
                                     (('s', 's_0'),))))
         self.assertEqual(variables + ['s_0'], map(str, original_system.variables))
-        self.assertEqual(original_system.power_matrix(), sympy.Matrix([[ 1, 1,  1, 1, 1, 1,  1,  0],
+        self.assertEqual(original_system.exponent_matrix(), sympy.Matrix([[ 1, 1,  1, 1, 1, 1,  1,  0],
                                                                        [-1, 0, -1, 0, 0, 1,  1,  1],
                                                                        [ 1, 0,  1, 1, 0, 0, -1,  0],
                                                                        [ 0, 0,  1, 0, 1, 0,  0,  0],

--- a/docs/source/examples/mm_basic.rst
+++ b/docs/source/examples/mm_basic.rst
@@ -50,7 +50,7 @@ First we make the system in Python from LaTeX code.
 
 We can see the system's properties
 
-    >>> system.power_matrix()
+    >>> system.exponent_matrix()
     Matrix([
     [1, 1,  1, 1, 1, 1,  1],
     [0, 0, -1, 1, 0, 0,  1],

--- a/docs/source/examples/mm_init_cond.rst
+++ b/docs/source/examples/mm_init_cond.rst
@@ -51,7 +51,7 @@ To match the analysis in Murray, We need to add in our initial condition for :ma
     >>> system.update_initial_conditions({'s': 's_0'})
 
 
-    >>> system.power_matrix()
+    >>> system.exponent_matrix()
     Matrix([
     [1, 1, 1,  1, 1, 1,  1,  0,  0,  0],
     [0, 0, 0, -1, 0, 1,  1,  0,  0,  0],

--- a/docs/source/ode_system_doc.rst
+++ b/docs/source/ode_system_doc.rst
@@ -21,7 +21,7 @@ There are a number of different ways of creating an :class:`~desr.ode_system.ODE
 Finding Scaling Actions
 -----------------------
 
-.. automethod:: desr.ode_system.ODESystem.power_matrix
+.. automethod:: desr.ode_system.ODESystem.exponent_matrix
     :noindex:
 .. automethod:: desr.ode_system.ODESystem.maximal_scaling_matrix
     :noindex:

--- a/examples/cell_cycle_control_network.py
+++ b/examples/cell_cycle_control_network.py
@@ -10,7 +10,7 @@ Adapted from: J. C. S. . J. J. Tyson, Mathematical modeling as a tool for invest
 import sympy
 from desr.matrix_normal_forms import smf
 from desr.ode_system import ODESystem
-from desr.ode_system import maximal_scaling_matrix, rational_expr_to_power_matrix, hnf_col, hnf_row, normal_hnf_col
+from desr.ode_system import maximal_scaling_matrix, rational_expr_to_exponent_matrix, hnf_col, hnf_row, normal_hnf_col
 from desr.matrix_normal_forms import normal_hnf_row
 from desr.ode_translation import ODETranslation, scale_action
 from desr.tex_tools import expr_to_tex, matrix_to_tex

--- a/examples/dimensional_consistency.py
+++ b/examples/dimensional_consistency.py
@@ -1,7 +1,7 @@
 import sympy
 from desr.matrix_normal_forms import smf
 from desr.ode_system import ODESystem
-from desr.ode_system import maximal_scaling_matrix, rational_expr_to_power_matrix, hnf_col, hnf_row, normal_hnf_col
+from desr.ode_system import maximal_scaling_matrix, rational_expr_to_exponent_matrix, hnf_col, hnf_row, normal_hnf_col
 from desr.matrix_normal_forms import normal_hnf_row
 from desr.ode_translation import ODETranslation, scale_action
 from desr.tex_tools import expr_to_tex, matrix_to_tex

--- a/examples/linear_compartment.py
+++ b/examples/linear_compartment.py
@@ -15,7 +15,7 @@
 import sympy
 from desr.matrix_normal_forms import smf
 from desr.ode_system import ODESystem
-from desr.ode_system import maximal_scaling_matrix, rational_expr_to_power_matrix, hnf_col, hnf_row, normal_hnf_col
+from desr.ode_system import maximal_scaling_matrix, rational_expr_to_exponent_matrix, hnf_col, hnf_row, normal_hnf_col
 from desr.matrix_normal_forms import normal_hnf_row
 from desr.ode_translation import ODETranslation, scale_action
 from desr.tex_tools import expr_to_tex, matrix_to_tex

--- a/examples/michaelis_menten.py
+++ b/examples/michaelis_menten.py
@@ -16,7 +16,7 @@ articlerender.fcgi?artid=PMC3991559.
 import sympy
 from desr.matrix_normal_forms import smf
 from desr.ode_system import ODESystem
-from desr.ode_system import maximal_scaling_matrix, rational_expr_to_power_matrix, hnf_col, hnf_row, normal_hnf_col
+from desr.ode_system import maximal_scaling_matrix, rational_expr_to_exponent_matrix, hnf_col, hnf_row, normal_hnf_col
 from desr.matrix_normal_forms import normal_hnf_row
 from desr.ode_translation import ODETranslation, scale_action
 from desr.tex_tools import expr_to_tex, matrix_to_tex
@@ -210,7 +210,7 @@ def michaelis_menten_two_variable(verbose=True):
         # Print variable order
         print('Variable order: ', reduced_system_km1.variables)
         
-        print('Power Matrix:', reduced_system_km1.power_matrix().__repr__())
+        print('Power Matrix:', reduced_system_km1.exponent_matrix().__repr__())
         
         # Print scaling matrices
         max_scal1 = ODETranslation.from_ode_system(reduced_system_km1)
@@ -298,7 +298,7 @@ def michaelis_menten_two_variable(verbose=True):
 
         print('Variable order: ', system.variables)
         
-        print('Power Matrix:', system.power_matrix().__repr__())
+        print('Power Matrix:', system.exponent_matrix().__repr__())
         translation = ODETranslation.from_ode_system(system, naming_scheme=('tau',['u','v'], 'c'))
         
         
@@ -367,7 +367,7 @@ def michaelis_menten_two_variable(verbose=True):
         
         # Print variable order
         
-        print('Power Matrix:', reduced_system_km1.power_matrix().__repr__())
+        print('Power Matrix:', reduced_system_km1.exponent_matrix().__repr__())
         print('constants: ',reduced_system_km1.constant_variables)
 
         max_scal2 = ODETranslation.from_ode_system(reduced_system_km1)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='desr',
-    version='1.0.2',
+    version='1.1.0',
     packages=['desr',],
     author='Richard Tanburn, Silviana Amethyst',
     author_email='richard.tanburn@gmail.com, amethyst@mpi-cbg.de',


### PR DESCRIPTION
renamed function to be more consistent with the paper.  Since this breaks user interface, a minor version bump was necessary.